### PR TITLE
Changed order of parameters in phpdoc declaration for runCommand()

### DIFF
--- a/Classes/Command/FakerCommandController.php
+++ b/Classes/Command/FakerCommandController.php
@@ -9,14 +9,14 @@ use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
 
 class FakerCommandController extends CommandController
 {
-    /**
-     * Generate dummy data
-     *
-     * @param string $table table name
-     * @param int $pid page id
-     * @param string $locale locale
-     * @param int $amount
-     */
+	/**
+	 * Generate dummy data
+	 *
+	 * @param string $table table name
+	 * @param int $pid page id
+	 * @param int $amount amount
+	 * @param string $locale locale
+	 */
     public function runCommand($table, $pid, $amount, $locale = Factory::DEFAULT_LOCALE)
     {
         $this->checkValidTableName($table);


### PR DESCRIPTION
Changed order of parameters in phpdoc declaration to make sure they represent the correct parameter in the runCommand method inside FakerCommandController.php. This way, the locale can be overwritten by using it as a parameter in the command.