### PR TITLE
TYPO3 9 compatibility

### DIFF
--- a/Classes/Command/FakerCommandController.php
+++ b/Classes/Command/FakerCommandController.php
@@ -15,8 +15,9 @@ class FakerCommandController extends CommandController
      *
      * @param string $table table name
      * @param int $pid page id
-     * @param string $locale locale
      * @param int $amount
+     * @param string $locale locale
+     * @return void
      */
     public function runCommand($table, $pid, $amount, $locale = Factory::DEFAULT_LOCALE)
     {
@@ -30,6 +31,7 @@ class FakerCommandController extends CommandController
      * @param string $table table name
      * @param int $pid page id
      * @param string $locale locale
+     * @return void
      */
     public function replaceCommand($table, $pid = -1, $locale = Factory::DEFAULT_LOCALE)
     {
@@ -42,6 +44,7 @@ class FakerCommandController extends CommandController
      * @param int $pid
      * @param string $locale
      * @param $amount
+     * @return void
      */
     protected function executeFaker($table, $pid, $locale, $amount)
     {
@@ -54,6 +57,7 @@ class FakerCommandController extends CommandController
      * @param string $table
      * @param int $pid
      * @param string $locale
+     * @return void
      */
     protected function executeReplaceFaker($table, $pid, $locale)
     {
@@ -64,6 +68,7 @@ class FakerCommandController extends CommandController
 
     /**
      * @param string $table
+     * @return void
      */
     protected function checkValidTableName($table)
     {

--- a/Classes/Command/FakerCommandController.php
+++ b/Classes/Command/FakerCommandController.php
@@ -3,6 +3,7 @@
 namespace GeorgRinger\Faker\Command;
 
 use Faker\Factory;
+use GeorgRinger\Faker\Generator\ReplaceRunner;
 use GeorgRinger\Faker\Generator\Runner;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\CommandController;
@@ -24,6 +25,19 @@ class FakerCommandController extends CommandController
     }
 
     /**
+     * Replace existing data with dummy data
+     *
+     * @param string $table table name
+     * @param int $pid page id
+     * @param string $locale locale
+     */
+    public function replaceCommand($table, $pid = -1, $locale = Factory::DEFAULT_LOCALE)
+    {
+        $this->checkValidTableName($table);
+        $this->executeReplaceFaker($table, $pid, $locale);
+    }
+
+    /**
      * @param string $table
      * @param int $pid
      * @param string $locale
@@ -31,8 +45,21 @@ class FakerCommandController extends CommandController
      */
     protected function executeFaker($table, $pid, $locale, $amount)
     {
+        /** @var Runner $runner */
         $runner = GeneralUtility::makeInstance(Runner::class, $table, $pid, $locale);
         $runner->execute($amount);
+    }
+
+    /**
+     * @param string $table
+     * @param int $pid
+     * @param string $locale
+     */
+    protected function executeReplaceFaker($table, $pid, $locale)
+    {
+        /** @var ReplaceRunner $runner */
+        $runner = GeneralUtility::makeInstance(ReplaceRunner::class, $table, $pid, $locale);
+        $runner->execute();
     }
 
     /**

--- a/Classes/Generator/ReplaceRunner.php
+++ b/Classes/Generator/ReplaceRunner.php
@@ -5,7 +5,7 @@ namespace GeorgRinger\Faker\Generator;
 use Faker\Factory;
 use Faker\Generator;
 use GeorgRinger\Faker\Property\PropertyInterface;
-use TYPO3\CMS\Core\Database\DatabaseConnection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -46,16 +46,15 @@ class ReplaceRunner implements SingletonInterface
      */
     public function execute()
     {
-        $where = '';
+        /** @var \TYPO3\CMS\Core\Database\Query\QueryBuilder$queryBuilder */
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($this->table);
+        $queryBuilder->select('*')->from($this->table);
+
         if ($this->pid > -1) {
-            $where = 'pid = ' . (int)$this->pid;
+            $queryBuilder->where($queryBuilder->expr()->eq('pid', $this->pid));
         }
 
-        $records = $this->getDatabaseConnection()->exec_SELECTgetRows(
-            'uid',
-            $this->table,
-            $where
-        );
+        $records = $queryBuilder->execute();
 
         $dataMap = [];
         foreach ($records as $record) {
@@ -95,13 +94,5 @@ class ReplaceRunner implements SingletonInterface
         }
 
         return $fields;
-    }
-
-    /**
-     * @return DatabaseConnection
-     */
-    protected function getDatabaseConnection()
-    {
-        return $GLOBALS['TYPO3_DB'];
     }
 }

--- a/Classes/Generator/ReplaceRunner.php
+++ b/Classes/Generator/ReplaceRunner.php
@@ -82,6 +82,9 @@ class ReplaceRunner implements SingletonInterface
         return $filled;
     }
 
+    /**
+     * @return array
+     */
     protected function getFakerFields()
     {
         $fields = [];

--- a/Classes/Generator/ReplaceRunner.php
+++ b/Classes/Generator/ReplaceRunner.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace GeorgRinger\Faker\Generator;
+
+use Faker\Factory;
+use Faker\Generator;
+use GeorgRinger\Faker\Property\PropertyInterface;
+use TYPO3\CMS\Core\Database\DatabaseConnection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class ReplaceRunner implements SingletonInterface
+{
+
+    /** @var DataHandler */
+    protected $dataHandler;
+
+    /** @var string */
+    protected $table;
+
+    /** @var int */
+    protected $pid;
+
+    /** @var Generator */
+    protected $faker;
+
+    /**
+     * Runner constructor.
+     * @param string $table
+     * @param int $pid
+     * @param string $locale
+     */
+    public function __construct($table, $pid, $locale)
+    {
+        $this->dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $this->table = $table;
+        $this->pid = $pid;
+        $this->faker = Factory::create($locale);
+    }
+
+    /**
+     * Execute
+     *
+     * @return void
+     */
+    public function execute()
+    {
+        $where = '';
+        if ($this->pid > -1) {
+            $where = 'pid = ' . (int)$this->pid;
+        }
+
+        $records = $this->getDatabaseConnection()->exec_SELECTgetRows(
+            'uid',
+            $this->table,
+            $where
+        );
+
+        $dataMap = [];
+        foreach ($records as $record) {
+            $dataMap[$this->table][$record['uid']] = $this->createRecordFields();
+        }
+
+        $GLOBALS['BE_USER']->user['admin'] = true;
+        $this->dataHandler->start($dataMap, []);
+        $this->dataHandler->admin = true;
+        $this->dataHandler->process_datamap();
+    }
+
+    /**
+     * @return array
+     */
+    protected function createRecordFields()
+    {
+        $filled = [];
+        foreach ($this->getFakerFields() as $name => $config) {
+            /** @var PropertyInterface $property */
+            $property = GeneralUtility::makeInstance($config['type']);
+            $filled[$name] = $property->generate($this->faker, $config);
+        }
+        return $filled;
+    }
+
+    protected function getFakerFields()
+    {
+        $fields = [];
+        foreach ($GLOBALS['TCA'][$this->table]['columns'] as $name => $field) {
+            if (isset($field['faker']) && empty($field['fakerDoNotReplace'])) {
+                $fields[$name] = $field['faker'];
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @return DatabaseConnection
+     */
+    protected function getDatabaseConnection()
+    {
+        return $GLOBALS['TYPO3_DB'];
+    }
+}

--- a/Classes/Generator/Runner.php
+++ b/Classes/Generator/Runner.php
@@ -28,6 +28,7 @@ class Runner implements SingletonInterface
      * Runner constructor.
      * @param string $table
      * @param int $pid
+     * @param string $locale
      */
     public function __construct($table, $pid, $locale)
     {
@@ -37,6 +38,10 @@ class Runner implements SingletonInterface
         $this->faker = Factory::create($locale);
     }
 
+    /**
+     * @param int $amount
+     * @return void
+     */
     public function execute($amount = 1)
     {
         $dataMap = [];
@@ -68,7 +73,9 @@ class Runner implements SingletonInterface
         return $filled;
     }
 
-
+    /**
+     * @return array
+     */
     protected function getFakerFields()
     {
         $fields = [];

--- a/Classes/Generator/Runner.php
+++ b/Classes/Generator/Runner.php
@@ -66,6 +66,10 @@ class Runner implements SingletonInterface
         ];
 
         foreach ($this->getFakerFields() as $name => $config) {
+            if (!empty($config['pid']) && $config['pid'] === 'current') {
+                $config['pid'] = $this->pid;
+            }
+
             /** @var PropertyInterface $property */
             $property = GeneralUtility::makeInstance($config['type']);
             $filled[$name] = $property->generate($this->faker, $config);

--- a/Classes/Property/City.php
+++ b/Classes/Property/City.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class City implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->city;
+    }
+
+}

--- a/Classes/Property/Country.php
+++ b/Classes/Property/Country.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class Country implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->country;
+    }
+
+}

--- a/Classes/Property/DefaultPassword.php
+++ b/Classes/Property/DefaultPassword.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class DefaultPassword implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+            'password' => $configuration['password'],
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $configuration['password'];
+    }
+
+}

--- a/Classes/Property/EmptyString.php
+++ b/Classes/Property/EmptyString.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class EmptyString implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return '';
+    }
+
+}

--- a/Classes/Property/FirstName.php
+++ b/Classes/Property/FirstName.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class FirstName implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->firstName;
+    }
+
+}

--- a/Classes/Property/LastName.php
+++ b/Classes/Property/LastName.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class LastName implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->lastName;
+    }
+
+}

--- a/Classes/Property/PhoneNumber.php
+++ b/Classes/Property/PhoneNumber.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class PhoneNumber implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->phoneNumber;
+    }
+
+}

--- a/Classes/Property/Postcode.php
+++ b/Classes/Property/Postcode.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class Postcode implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->postcode;
+    }
+
+}

--- a/Classes/Property/Relation.php
+++ b/Classes/Property/Relation.php
@@ -47,6 +47,12 @@ class Relation implements PropertyInterface
         return '';
     }
 
+    /**
+     * @param array $arr
+     * @param int $num
+     *
+     * @return array Returns an array with random $num elements from original array
+     */
     protected function array_random($arr, $num = 1)
     {
         if ($num === 0) {
@@ -58,6 +64,6 @@ class Relation implements PropertyInterface
         for ($i = 0; $i < $num; $i++) {
             $r[] = $arr[$i];
         }
-        return $num == 1 ? $r[0] : $r;
+        return $r;
     }
 }

--- a/Classes/Property/Relation.php
+++ b/Classes/Property/Relation.php
@@ -13,7 +13,7 @@ class Relation implements PropertyInterface
         return [
             'type' => self::class,
             'table' => $configuration['table'],
-            'pid' => $configuration['pid'],
+            'pid' => isset($configuration['pid']) ? $configuration['pid'] : 'current',
             'min' => $configuration['min'],
             'max' => $configuration['max'],
         ];

--- a/Classes/Property/SafeEmail.php
+++ b/Classes/Property/SafeEmail.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class SafeEmail implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->safeEmail;
+    }
+
+}

--- a/Classes/Property/StreetAddress.php
+++ b/Classes/Property/StreetAddress.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class StreetAddress implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->streetAddress;
+    }
+
+}

--- a/Classes/Property/Url.php
+++ b/Classes/Property/Url.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class Url implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->url;
+    }
+
+}

--- a/Classes/Property/Username.php
+++ b/Classes/Property/Username.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+
+class Username implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        return [
+            'type' => self::class,
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->userName;
+    }
+
+}

--- a/Classes/Property/Words.php
+++ b/Classes/Property/Words.php
@@ -1,0 +1,25 @@
+<?php
+namespace GeorgRinger\Faker\Property;
+
+use Faker\Generator;
+use TYPO3\CMS\Core\Utility\MathUtility;
+
+class Words implements PropertyInterface
+{
+    static public function getSettings(array $configuration = [])
+    {
+        $min = MathUtility::forceIntegerInRange((int)$configuration['min'], 0, 20, 2);
+        $max = $configuration['max'] ?: $min;
+        return [
+            'type' => self::class,
+            'min' => $min,
+            'max' => $max
+        ];
+    }
+
+    public function generate(Generator $faker, array $configuration = [])
+    {
+        return $faker->words(rand($configuration['min'], $configuration['max']), true);
+    }
+
+}

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -1,0 +1,22 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+$t = 'fe_users';
+if (isset($GLOBALS['TCA'][$t])) {
+    $GLOBALS['TCA']['fe_users']['ctrl']['faker'] = true;
+
+    $GLOBALS['TCA']['fe_users']['columns']['username']['faker'] = \GeorgRinger\Faker\Property\Username::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['password']['faker'] = \GeorgRinger\Faker\Property\DefaultPassword::getSettings(['password' => 'Welcome01!']);
+    $GLOBALS['TCA']['fe_users']['columns']['name']['faker'] = \GeorgRinger\Faker\Property\FullName::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['first_name']['faker'] = \GeorgRinger\Faker\Property\FirstName::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['middle_name']['faker'] = \GeorgRinger\Faker\Property\EmptyString::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['last_name']['faker'] = \GeorgRinger\Faker\Property\LastName::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['address']['faker'] = \GeorgRinger\Faker\Property\StreetAddress::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['telephone']['faker'] = \GeorgRinger\Faker\Property\PhoneNumber::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['email']['faker'] = \GeorgRinger\Faker\Property\SafeEmail::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['zip']['faker'] = \GeorgRinger\Faker\Property\Postcode::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['city']['faker'] = \GeorgRinger\Faker\Property\City::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['country']['faker'] = \GeorgRinger\Faker\Property\Country::getSettings([]);
+    $GLOBALS['TCA']['fe_users']['columns']['www']['faker'] = \GeorgRinger\Faker\Property\Url::getSettings([]);
+}
+unset($t);

--- a/Configuration/TCA/Overrides/sys_category.php
+++ b/Configuration/TCA/Overrides/sys_category.php
@@ -2,4 +2,4 @@
 defined('TYPO3_MODE') or die();
 
 $GLOBALS['TCA']['sys_category']['ctrl']['faker'] = true;
-$GLOBALS['TCA']['sys_category']['columns']['title']['faker'] = \GeorgRinger\Faker\Property\Text::getSettings(['from' => 8, 'to' => 20]);
+$GLOBALS['TCA']['sys_category']['columns']['title']['faker'] = \GeorgRinger\Faker\Property\Words::getSettings(['min' => 1, 'max' => 3]);

--- a/Configuration/TCA/Overrides/tx_news_domain_model_news.php
+++ b/Configuration/TCA/Overrides/tx_news_domain_model_news.php
@@ -8,18 +8,17 @@ if (isset($GLOBALS['TCA'][$t])) {
     $GLOBALS['TCA'][$t]['columns']['fal_media']['config']['appearance']['elementBrowserEnabled'] = false;
 
     $GLOBALS['TCA'][$t]['columns']['title']['faker'] = \GeorgRinger\Faker\Property\Text::getSettings(['from' => 15, 'to' => 60]);
-    $GLOBALS['TCA'][$t]['columns']['teaser']['faker'] = \GeorgRinger\Faker\Property\Text::getSettings(['from' => 40, 'to' => 150]);
-    $GLOBALS['TCA'][$t]['columns']['bodytext']['faker'] = \GeorgRinger\Faker\Property\Text::getSettings(['from' => 200, 'to' => 650]);
+    $GLOBALS['TCA'][$t]['columns']['teaser']['faker'] = \GeorgRinger\Faker\Property\Text::getSettings(['from' => 100, 'to' => 1500]);
+    $GLOBALS['TCA'][$t]['columns']['bodytext']['faker'] = \GeorgRinger\Faker\Property\Text::getSettings(['from' => 500, 'to' => 10000]);
     $GLOBALS['TCA'][$t]['columns']['categories']['faker'] = \GeorgRinger\Faker\Property\Relation::getSettings([
             'table' => 'sys_category',
-            'pid' => 113,
-            'min' => 1,
+            'min' => 0,
             'max' => 5]
     );
     $GLOBALS['TCA'][$t]['columns']['author']['faker'] = \GeorgRinger\Faker\Property\FullName::getSettings([]);
     $GLOBALS['TCA'][$t]['columns']['datetime']['faker'] = \GeorgRinger\Faker\Property\Date::getSettings([
-        'from' => 'yesterday',
-        'to' => '+2months',
+        'from' => '-2months',
+        'to' => 'yesterday',
     ]);
 }
 unset($t);

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "GPL-2.0+"
   ],
   "require": {
-    "typo3/cms-core": ">=7.6.0,<8.9.99",
+    "typo3/cms-core": ">=8.7.0,<9.5.99",
     "fzaninotto/faker": "1.6.*"
   },
   "require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,7 +8,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'georg.ringer@gmail.com',
     'state' => 'alpha',
     'clearCacheOnLoad' => true,
-    'version' => '1.0.0',
+    'version' => '1.0.1',
     'constraints' =>
         [
             'depends' => [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,11 +8,11 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'georg.ringer@gmail.com',
     'state' => 'alpha',
     'clearCacheOnLoad' => true,
-    'version' => '1.0.1',
+    'version' => '1.1.0',
     'constraints' =>
         [
             'depends' => [
-                'typo3' => '7.6.0-8.9.99'
+                'typo3' => '8.7.0-9.5.99'
             ],
             'conflicts' => [],
             'suggests' => [],


### PR DESCRIPTION
It's basically this:
* TYPO3 9 compatibility
* New fakers: City, Country, DefaultPassword, EmptyString, FirstName, LastName, PhoneNumber, PostCode, SafeEmail, StreetAddress, Url, Username, Words
* Faker config for fe_users
* New feature for Relation: current pid
* New command for replacing existing fake data

@georgringer, you'd rather like separate PRs for this?