### PR TITLE
Fix deprecation warning on packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
     }
   },
   "replace": {
-    "faker": "self.version",
     "typo3-ter/faker": "self.version"
   },
   "config": {


### PR DESCRIPTION
Packagist won't update its references as long as the replace-block is invalid:
```
Reading composer.json of georgringer/faker (master)
Importing branch master (dev-master)
Skipped branch master, Invalid package information: 
Deprecation warning: replace.faker is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$". Make sure you fix this as Composer 2.0 will error.
```