### PR TITLE
[BUGFIX] Add return type to method execute

### DIFF
--- a/Classes/Command/FakerCommand.php
+++ b/Classes/Command/FakerCommand.php
@@ -67,7 +67,7 @@ class FakerCommand extends Command
      * @param OutputInterface $output
      * @return int error code
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = new SymfonyStyle($input, $output);
 


### PR DESCRIPTION
With this change, the return type is added to the method `execute` along the implementation of the class `Symfony\Component\Console\Command`

Fixes #26 