### PR TITLE
[BUGFIX] Use optional command argument "locale"

### DIFF
--- a/Classes/Command/FakerCommand.php
+++ b/Classes/Command/FakerCommand.php
@@ -71,7 +71,7 @@ class FakerCommand extends Command
     {
         $this->output = new SymfonyStyle($input, $output);
 
-        $locale = Factory::DEFAULT_LOCALE;
+        $locale = $input->getArgument('locale') ?: Factory::DEFAULT_LOCALE;
         $amount = $input->getArgument('amount') ?: 1;
         $pid = $input->getArgument('pid') ?: -1;
         $table = $input->getArgument('table');


### PR DESCRIPTION
With this change, the optional command argument "locale" is used and if not provided, it will fall back to the default value of Faker.

Fixes #28