### PR TITLE
[BUGFIX] Type error: $pid musst be of type int

### DIFF
--- a/Classes/Command/FakerCommand.php
+++ b/Classes/Command/FakerCommand.php
@@ -73,7 +73,7 @@ class FakerCommand extends Command
 
         $locale = $input->getArgument('locale') ?: Factory::DEFAULT_LOCALE;
         $amount = $input->getArgument('amount') ?: 1;
-        $pid = $input->getArgument('pid') ?: -1;
+        $pid = (int)$input->getArgument('pid') ?: -1;
         $table = $input->getArgument('table');
 
         \TYPO3\CMS\Core\Core\Bootstrap::initializeBackendAuthentication();


### PR DESCRIPTION
In #30 typed arguments have been introduced to `Runner` and `ReplaceRunner`, however the `$pid` argument is never casted to int.