### PR TITLE
[TASK] Add Functional Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - functional-tests
   pull_request:
     branches:
       - master
@@ -67,5 +66,4 @@ jobs:
           typo3DatabaseName: db
         run:  |
           sudo /etc/init.d/mysql start
-          mysql -e 'CREATE DATABASE db;' -uroot -proot
           .Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml Tests/Functional/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - functional-tests
   pull_request:
     branches:
       - master
@@ -51,3 +52,12 @@ jobs:
 
       - name: Run Unit Tests
         run: .Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml Tests/Unit/
+
+      - name: Run Functional Tests
+        if: matrix.php-version != '7.4'
+        env:
+          typo3DatabaseHost: 127.0.0.1
+          typo3DatabaseUsername: root
+          typo3DatabasePassword: root
+          typo3DatabaseName: db
+        run: .Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml Tests/Functional/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=30s
+          --health-timeout=10s
+          --health-retries=5
+
     strategy:
       matrix:
         include:
@@ -56,8 +69,9 @@ jobs:
       - name: Run Functional Tests
         if: matrix.php-version != '7.4'
         env:
-          typo3DatabaseHost: 127.0.0.1
+          typo3DatabaseHost: mariadb
+          typo3DatabasePort: 3306
           typo3DatabaseUsername: root
           typo3DatabasePassword: root
-          typo3DatabaseName: db
+          typo3DatabaseName: test
         run: .Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml Tests/Functional/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,19 +12,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    services:
-      mariadb:
-        image: mariadb:10.11
-        env:
-          MARIADB_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping --silent"
-          --health-interval=30s
-          --health-timeout=10s
-          --health-retries=5
+    env:
+      DB_DATABASE: test_db
+      DB_USER: root
+      DB_PASSWORD: root
 
     strategy:
       matrix:
@@ -69,9 +60,11 @@ jobs:
       - name: Run Functional Tests
         if: matrix.php-version != '7.4'
         env:
-          typo3DatabaseHost: mariadb
+          typo3DatabaseHost: 127.0.0.1
           typo3DatabasePort: 3306
           typo3DatabaseUsername: root
           typo3DatabasePassword: root
-          typo3DatabaseName: test
-        run: .Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml Tests/Functional/
+        run:  |
+          sudo /etc/init.d/mysql start
+          mysql -e 'CREATE DATABASE db;' -uroot -proot
+          .Build/bin/phpunit -c .Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml Tests/Functional/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DB_DATABASE: test_db
+      DB_DATABASE: db
       DB_USER: root
       DB_PASSWORD: root
 
@@ -64,6 +64,7 @@ jobs:
           typo3DatabasePort: 3306
           typo3DatabaseUsername: root
           typo3DatabasePassword: root
+          typo3DatabaseName: db
         run:  |
           sudo /etc/init.d/mysql start
           mysql -e 'CREATE DATABASE db;' -uroot -proot

--- a/Classes/Command/FakerCommand.php
+++ b/Classes/Command/FakerCommand.php
@@ -73,7 +73,7 @@ class FakerCommand extends Command
 
         $locale = $input->getArgument('locale') ?: Factory::DEFAULT_LOCALE;
         $amount = $input->getArgument('amount') ?: 1;
-        $pid = $input->getArgument('pid') ?: -1;
+        $pid = (int)$input->getArgument('pid') ?: -1;
         $table = $input->getArgument('table');
 
         \TYPO3\CMS\Core\Core\Bootstrap::initializeBackendAuthentication();

--- a/Tests/Functional/Command/FakerCommandTest.php
+++ b/Tests/Functional/Command/FakerCommandTest.php
@@ -22,14 +22,14 @@ class FakerCommandTest extends FunctionalTestCase
     {
         yield 'Categories' => [
             'tableName' => 'sys_category',
-            'amount' => 10,
+            'expect' => 10,
             'columns' => [
                 'text' => ['title'],
             ],
         ];
         yield 'Frontend Users' => [
             'tableName' => 'fe_users',
-            'amount' => 1,
+            'expect' => 5,
             'columns' => [
                 'text' => [
                     'username',
@@ -49,7 +49,7 @@ class FakerCommandTest extends FunctionalTestCase
         ];
         yield 'News' => [
             'tableName' => 'tx_news_domain_model_news',
-            'amount' => 5,
+            'expect' => 5,
             'columns' => [
                 'text' => ['title', 'teaser', 'bodytext', 'author'],
                 'relation' => ['categories'],
@@ -61,12 +61,12 @@ class FakerCommandTest extends FunctionalTestCase
     /**
      * @dataProvider fakerInstractionDataProvider
      */
-    public function testFakerCommand(string $tableName, int $amount, array $columns): void
+    public function testFakerCommand(string $tableName, int $expect, array $columns): void
     {
         $this->commandTester->execute([
             'table' => $tableName,
             'pid' => '2',
-            'amount' => (string)$amount,
+            'amount' => '5',
         ]);
 
         $qb = $this->getConnectionPool()->getQueryBuilderForTable($tableName);
@@ -76,18 +76,18 @@ class FakerCommandTest extends FunctionalTestCase
             ->fetchAllAssociative();
 
         self::assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
-        self::assertCount($amount, $records);
+        self::assertCount($expect, $records);
 
         $record = $records[0];
         foreach ($columns['text'] ?? [] as $textField) {
             self::assertIsString($record[$textField]);
             self::assertNotEmpty($record[$textField]);
         }
-        foreach ($coumns['relation'] ?? [] as $relationField) {
+        foreach ($columns['relation'] ?? [] as $relationField) {
             self::assertIsInt($record[$relationField]);
-            self::assertGreaterThan(0, $record[$relationField]);
+            self::assertLessThanOrEqual(5, $record[$relationField]);
         }
-        foreach ($coumns['date'] ?? [] as $dateField) {
+        foreach ($columns['date'] ?? [] as $dateField) {
             self::assertIsInt($record[$dateField]);
             self::assertGreaterThan(0, $record[$dateField]);
         }
@@ -99,6 +99,7 @@ class FakerCommandTest extends FunctionalTestCase
 
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/pages.csv');
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/sys_category.csv');
         $this->setUpBackendUser(1);
 
         $languageFactory = GeneralUtility::makeInstance(LanguageServiceFactory::class);

--- a/Tests/Functional/Command/FakerCommandTest.php
+++ b/Tests/Functional/Command/FakerCommandTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace GeorgRinger\Faker\Tests\Functional\Command;
+
+use GeorgRinger\Faker\Command\FakerCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+class FakerCommandTest extends FunctionalTestCase
+{
+    protected CommandTester $commandTester;
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/faker',
+        'typo3conf/ext/news',
+    ];
+
+    public static function fakerInstractionDataProvider(): iterable
+    {
+        yield 'Categories' => [
+            'tableName' => 'sys_category',
+            'amount' => 10,
+            'columns' => [
+                'text' => ['title'],
+            ],
+        ];
+        yield 'Frontend Users' => [
+            'tableName' => 'fe_users',
+            'amount' => 1,
+            'columns' => [
+                'text' => [
+                    'username',
+                    'password',
+                    'name',
+                    'first_name',
+                    'last_name',
+                    'address',
+                    'telephone',
+                    'email',
+                    'zip',
+                    'city',
+                    'country',
+                    'www',
+                ],
+            ],
+        ];
+        yield 'News' => [
+            'tableName' => 'tx_news_domain_model_news',
+            'amount' => 5,
+            'columns' => [
+                'text' => ['title', 'teaser', 'bodytext', 'author'],
+                'relation' => ['categories'],
+                'date' => ['datetime'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider fakerInstractionDataProvider
+     */
+    public function testFakerCommand(string $tableName, int $amount, array $columns): void
+    {
+        $this->commandTester->execute([
+            'table' => $tableName,
+            'pid' => '2',
+            'amount' => (string)$amount,
+        ]);
+
+        $qb = $this->getConnectionPool()->getQueryBuilderForTable($tableName);
+        $records = $qb->select('*')
+            ->from($tableName)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        self::assertEquals(Command::SUCCESS, $this->commandTester->getStatusCode());
+        self::assertCount($amount, $records);
+
+        $record = $records[0];
+        foreach ($columns['text'] ?? [] as $textField) {
+            self::assertIsString($record[$textField]);
+            self::assertNotEmpty($record[$textField]);
+        }
+        foreach ($coumns['relation'] ?? [] as $relationField) {
+            self::assertIsInt($record[$relationField]);
+            self::assertGreaterThan(0, $record[$relationField]);
+        }
+        foreach ($coumns['date'] ?? [] as $dateField) {
+            self::assertIsInt($record[$dateField]);
+            self::assertGreaterThan(0, $record[$dateField]);
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/be_users.csv');
+        $this->setUpBackendUser(1);
+
+        $languageFactory = GeneralUtility::makeInstance(LanguageServiceFactory::class);
+        $GLOBALS['LANG'] = $languageFactory->create('en');
+
+        $command = GeneralUtility::makeInstance(FakerCommand::class);
+        $this->commandTester = new CommandTester($command);
+    }
+}

--- a/Tests/Functional/Fixtures/be_users.csv
+++ b/Tests/Functional/Fixtures/be_users.csv
@@ -1,0 +1,3 @@
+"be_users",,,
+,"uid","pid","username","admin",
+,1,0,"admin",1,

--- a/Tests/Functional/Fixtures/pages.csv
+++ b/Tests/Functional/Fixtures/pages.csv
@@ -1,0 +1,4 @@
+"pages",,,
+,"uid","pid","title","is_siteroot","doktype",
+,1,0,"Home",1,1,
+,2,1,"Storage",1,254,

--- a/Tests/Functional/Fixtures/sys_category.csv
+++ b/Tests/Functional/Fixtures/sys_category.csv
@@ -1,0 +1,7 @@
+"sys_category",,,
+,"uid","pid","title",
+,1,2,"Category 1",
+,2,2,"Category 2",
+,3,2,"Category 3",
+,4,2,"Category 4",
+,5,2,"Category 5",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,10 @@
     "fakerphp/faker": "^1.23"
   },
   "require-dev": {
+    "georgringer/news": "^10.0 || ^11.0 || ^12.0",
     "php": "^7.4 || ^8.0",
     "phpunit/phpunit": "^9.6 || ^10.1",
+    "typo3/cms-install": "^10.4 || ^11.5 || ^12.4 || ^13.4",
     "typo3/testing-framework": "^6.16 || ^7.0 || ^8.0"
   },
   "autoload": {


### PR DESCRIPTION
This PR configures some basic functional tests for TYPO3 v11+.
* PHP 7.4 is currently excluded because of `protected array $testExtensionsToLoad`
* News extension is added as dev-dependency + needed `typo3/cms-install`
* It includes the bug fix of #33 

closes #33